### PR TITLE
Checkout repo so we can access default config

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -11,6 +11,8 @@ jobs:
     name: scala-steward
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo so our default config at .github/.scala-steward.conf is available.
+        uses: actions/checkout@v3
       - name: Generate token
         id: generate-token
         uses: tibdex/github-app-token@v1


### PR DESCRIPTION
Following on from #3 , [I realised the default config wasn't being found](https://github.com/scala-steward-org/scala-steward-action/issues/353#issuecomment-1185614639) - but that's because we weren't checking out the repository!

https://github.com/scala-steward-org/scala-steward-action/issues/353#issuecomment-1185638287
