### PR TITLE
Update reusable-scala-steward.yml

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -37,4 +37,4 @@ jobs:
           # Guardian Scala Steward GitHub App
           github-token: ${{ steps.generate-token.outputs.token }}
           repos-file: REPOSITORIES.md
-          repo-conf: common-config/scala-steward.conf # from checkout of guardian/scala-steward-public-repos
+          repo-config: common-config/scala-steward.conf # from checkout of guardian/scala-steward-public-repos


### PR DESCRIPTION
Fixes the typo from #6 :

https://github.com/guardian/scala-steward-public-repos/runs/7566428225?check_suite_focus=true#step:5:17