### PR TITLE
Adds guardian/amiable to list of repositories

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -1,3 +1,4 @@
+- guardian/amiable:dependency-updates
 - guardian/amigo
 - guardian/invoicing-api
 - guardian/manage-help-content-publisher


### PR DESCRIPTION
Following on from:

- https://github.com/guardian/amiable/pull/182
- https://github.com/guardian/.github/pull/23

Causes PRs to be opened on the non default branch [`dependency-updates`](https://github.com/guardian/amiable/pull/182/files#diff-05836425388f26ba06446b5c1272d551ace0f8f0e51fef3f41cec358e243d0f1R6) intended to then follow the [dependency update process](https://github.com/guardian/.github/pull/23/files#diff-9878c091051bb15a98b39f1494423c81bf09dafea3740080054300552c1454d6R1).