### PR TITLE
Reduce default frequency of v1 AWS SDK  updates

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -4,6 +4,10 @@
 # new releases consume more dev attention than they're worth!
 dependencyOverrides = [
   {
+    dependency = { groupId = "com.amazonaws" },
+    pullRequests = { frequency = "7 day" }
+  },
+  {
     dependency = { groupId = "software.amazon.awssdk" },
     pullRequests = { frequency = "30 day" }
   },


### PR DESCRIPTION
## What does this change?
Reduces the default frequency of PRs opened by Scala Steward for AWS SDK v1 changes to weekly (they seem to release every week day, but these changes aren't likely to ever be useful to treat separately). Unfortunately the group ID `com.amazonaws` includes non-java-SDK libraries which makes it impossible to treat these separately in scala stewards config. Our compromise is to use 7 day frequency, so that changes to non-SDK libraries are still relatively timely.

co-authored-by: @jacobwinch