### PR TITLE
Fix pull request frequency definitions

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -5,14 +5,14 @@
 dependencyOverrides = [
   {
     dependency = { groupId = "com.amazonaws" },
-    pullRequests = { frequency = "7 day" }
+    pullRequests = { frequency = "7 days" }
   },
   {
     dependency = { groupId = "software.amazon.awssdk" },
-    pullRequests = { frequency = "30 day" }
+    pullRequests = { frequency = "30 days" }
   },
   {
     dependency = { groupId = "com.google.apis" },
-    pullRequests = { frequency = "30 day" }
+    pullRequests = { frequency = "30 days" }
    }
 ]


### PR DESCRIPTION
## What does this change?
I noticed that our recently added rule for the `com.amazonaws` group was not restricting pull requests to every 7 days - we were still receiving them almost daily e.g. https://github.com/guardian/amiable/pulls?q=is%3Apr+is%3Aclosed+aws-java. Another piece of [evidence](https://github.com/guardian/ophan/pulls?q=is%3Apr+is%3Aclosed+software.amazon.awssdk) from Ophan: pull requests for the v2 SDK are every 7 days there, instead of 30 (it's only 7 days because they have a global setting for that.) On closer inspection it seems we're missing the pluralisation of the time span we use in the config file, so this PR fixes them.

## How to test
Hard to test, but not that risky to merge and observe.