### PR TITLE
Add ssm-scala to monitored projects

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -21,6 +21,7 @@
 - guardian/riff-raff:dependency-updates
 - guardian/salesforce-message-handler
 - guardian/security-hq:dependency-updates
+- guardian/ssm-scala
 - guardian/support-frontend
 - guardian/support-service-lambdas
 - guardian/zuora-6for6-modifier


### PR DESCRIPTION
## What does this change?

Adds [ssm-scala](https://github.com/guardian/ssm-scala) to monitored repos. This is a @guardian/devx-security repo and we should be on top of updates.

The application has been added to the repo already as [per the instructions](https://github.com/guardian/scala-steward-public-repos/blob/main/README.md).