### PR TITLE
Set the target branch for mobile-n10n to dependency-updates

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -10,7 +10,7 @@
 - guardian/members-data-api
 - guardian/membership-common
 - guardian/membership-frontend
-- guardian/mobile-n10n
+- guardian/mobile-n10n:dependency-updates
 - guardian/ophan-backfill-step-function
 - guardian/ophan-geoip-db-refresher
 - guardian/ophan-housekeeper


### PR DESCRIPTION
## What does this change?

The PR sets the target branch for Scala Steward to update mobile-n10n to `dependency-updates`

