### PR TITLE
Removed archived `ophan-backfill-step-function` repo

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -12,7 +12,6 @@
 - guardian/membership-common
 - guardian/membership-frontend
 - guardian/mobile-n10n:dependency-updates
-- guardian/ophan-backfill-step-function
 - guardian/ophan-geoip-db-refresher
 - guardian/ophan-housekeeper
 - guardian/payment-failure-comms


### PR DESCRIPTION
Scala Steward reports [an error](https://github.com/guardian/scala-steward-public-repos/actions/runs/4543359460/jobs/8007941838#step:6:968) (see also https://github.com/scala-steward-org/scala-steward/pull/2514) when it's asked to process archived repos:

>  2023-03-28 13:08:47,117 INFO  Check cache of guardian/ophan-backfill-step-function
>  2023-03-28 13:08:47,290 ERROR Steward guardian/ophan-backfill-step-function failed
>  org.scalasteward.core.forge.github.GitHubException$RepositoryArchived: guardian/ophan-backfill-step-function

...this has led to the [Public Repos Scala Steward](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml) workflow consistently being reported as failed (since [ophan-backfill-step-function](https://github.com/guardian/ophan-backfill-step-function) was archived a little while ago, along with https://github.com/guardian/ophan/pull/5258):

![image](https://user-images.githubusercontent.com/52038/228265408-f09001b1-7e6c-40da-8b74-5ed372ade867.png)

When we archive a Scala repo, we need to remember to remove it here too!