### PR TITLE
Reduce frequency of AWS patches

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -5,7 +5,7 @@
 dependencyOverrides = [
   {
     dependency = { groupId = "com.amazonaws" },
-    pullRequests = { frequency = "7 days" }
+    pullRequests = { frequency = "30 days" }
   },
   {
     dependency = { groupId = "software.amazon.awssdk" },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

`com.amazonaws` patches are released multiple times a week. Since the adoption of [actions-prnouncer](https://github.com/guardian/actions-prnouncer), DevX's PR reminders are very noisy, and well over half of our PRs are small version bumps. Other teams are probably having similar issues

## How can we measure success?

Teams spend less time reviewing/merging/closing noisy PRs. Commit history is cleaner.

## Have we considered potential risks?

A potential risk is a higher time to remediation for security vulnerabilities. This is largely mitigated by snyk, which will notify teams if their AWS dependencies are discovered to be vulnerable, and they can be easily patched ad-hoc
