### PR TITLE
Raise dependency updates for n10n against main branch

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -14,7 +14,7 @@
 - guardian/members-data-api
 - guardian/membership-common
 - guardian/membership-frontend
-- guardian/mobile-n10n:dependency-updates
+- guardian/mobile-n10n
 - guardian/ophan-geoip-db-refresher
 - guardian/ophan-housekeeper
 - guardian/pa-football-client


### PR DESCRIPTION
## What does this change?

Now that pull request [grouping](https://github.com/guardian/scala-steward-public-repos/pull/40) has been introduced we don't need the workflows associated with a `dependency-updates` branch to help reduce noise.

When we've merged this change, let's check we're happy with the automated PRs being raised by scala-steward, after which we can then safely delete the dependency-updates [workflows](https://github.com/guardian/mobile-n10n/tree/main/.github/workflows) from the n10n repo.