### PR TITLE
Remove `guardian/zuora-creditor` - archived, causing errors

### DIFF
--- a/REPOSITORIES.md
+++ b/REPOSITORIES.md
@@ -33,5 +33,4 @@
 - guardian/support-service-lambdas
 - guardian/typerighter
 - guardian/zuora-6for6-modifier
-- guardian/zuora-creditor
 - guardian/zuora-full-export


### PR DESCRIPTION
https://github.com/guardian/scala-steward-public-repos/actions/runs/5091072018/jobs/9150648602

![image](https://github.com/guardian/scala-steward-public-repos/assets/52038/2618f710-8762-4029-a8bc-352943287049)


```
2023-05-26 13:16:37,520 ERROR Steward guardian/zuora-creditor failed
org.scalasteward.core.forge.github.GitHubException$RepositoryArchived: guardian/zuora-creditor
```

Repository archived with https://github.com/guardian/zuora-creditor/pull/193 - when we archive a repo, we need to remove it from https://github.com/guardian/scala-steward-public-repos/blob/main/REPOSITORIES.md !

cc @gnm-notona & @shtukas