### PR TITLE
Change default frequency from 'asap' to weekly

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -3,8 +3,10 @@ pullRequests.grouping = [
   { name = "non_aws", "title" = "Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
-# Only limit frequency on dependencies which automatically release updates as frequently
-# as daily, without those dependencies having meaningful security value.
+# Weekly is a good balance between keeping secure and not being overwhelmed.
+pullRequests.frequency = "7 days"
+
+# Certain dependencies are noisy and should be updated less frequently.
 dependencyOverrides = [
   {
     dependency = { groupId = "com.amazonaws" },


### PR DESCRIPTION
While it is desirable to receive PRs for security updates immediately, we are getting overwhelmed with PRs at the moment and it is proving tricky to keep pace. A gentler cadence is preferred.

