### PR TITLE
Update to latest Scala Steward Action with new Job Summary

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -27,7 +27,7 @@ jobs:
           path: common-config
 
       - name: Execute Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2.54.0
+        uses: scala-steward-org/scala-steward-action@v2.55.0
 
         with:
           github-app-id: ${{ inputs.app_id }}


### PR DESCRIPTION
This includes https://github.com/scala-steward-org/scala-steward-action/pull/502, for a more friendly summary of which repos failed or succeeded as Scala Steward was processing them.

![image](https://github.com/guardian/scala-steward-public-repos/assets/52038/2eb51798-55b3-4e2b-a427-901e3a5311f7)

![image](https://github.com/guardian/scala-steward-public-repos/assets/52038/3e210432-c77f-448d-aa5f-d8adfdb15505)
