### PR TITLE
Ignore Akka dependencies

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -19,3 +19,8 @@ dependencyOverrides = [
     pullRequests = { frequency = "30 days" }
    }
 ]
+
+# Ignore Akka updates following licence changes. Note, we hope to provide better
+# solutions to this going forward; this is a crude sticking-plaster to avoid us
+# sleepwalking into lots of fees.
+updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ]


### PR DESCRIPTION
Akka have moved to a commercial licence for 2.7+, which we want to avoid. This is a temporary solution to help teams avoid upgrading to a commercial version accidentally.

Medium term, we are hoping that Snyk will fix their licence check for Akka. We can then rely on that instead.

For a fuller discussion, see https://github.com/guardian/scala-steward-public-repos/issues/53.