### PR TITLE
Temporarily use Scala Steward snapshot to fix dependency-frequency-limits

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -27,7 +27,7 @@ jobs:
           path: common-config
 
       - name: Execute Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2.56.0
+        uses: scala-steward-org/scala-steward-action@snapshots/514
 
         with:
           github-app-id: ${{ inputs.app_id }}

--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -27,8 +27,7 @@ jobs:
           path: common-config
 
       - name: Execute Scala Steward
-        uses: scala-steward-org/scala-steward-action@2.57.0
-        
+        uses: scala-steward-org/scala-steward-action@v2.57.0
         with:
           github-app-id: ${{ inputs.app_id }}
           github-app-installation-id: ${{ inputs.app_installation_id }}

--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -27,8 +27,8 @@ jobs:
           path: common-config
 
       - name: Execute Scala Steward
-        uses: scala-steward-org/scala-steward-action@snapshots/514
-
+        uses: scala-steward-org/scala-steward-action@2.57.0
+        
         with:
           github-app-id: ${{ inputs.app_id }}
           github-app-installation-id: ${{ inputs.app_installation_id }}

--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -33,5 +33,6 @@ jobs:
           github-app-id: ${{ inputs.app_id }}
           github-app-installation-id: ${{ inputs.app_installation_id }}
           github-app-key: ${{ secrets.private_key }}
+          scala-steward-version: 0.24.0-33-a3c0851a-SNAPSHOT # temporarily necessary for the fix in https://github.com/scala-steward-org/scala-steward/pull/3102
           repos-file: REPOSITORIES.md # possibly no longer necessary, thanks to `github-app-*` configuration
           repo-config: common-config/scala-steward.conf # from checkout of guardian/scala-steward-public-repos


### PR DESCRIPTION
The fix in https://github.com/scala-steward-org/scala-steward/pull/3102 (_"Don't ignore dependency-frequency-limits for *grouped* PRs"_) hasn't yet been released (it'll be in Scala Steward [v0.25.0](https://github.com/scala-steward-org/scala-steward/milestone/27)), but Scala Steward do release _snapshot_ versions of Scala Steward on all commits to the main branch:

https://oss.sonatype.org/content/repositories/snapshots/org/scala-steward/scala-steward-core_2.13/

The fix in https://github.com/scala-steward-org/scala-steward/pull/3102 was merged with merge commit [a3c0851a](https://github.com/scala-steward-org/scala-steward/commit/a3c0851ab597dd00eeaabb5bd3250d5582b99e41), and we can easily find that in the snapshots listing above - or check the [CI action logs](https://github.com/scala-steward-org/scala-steward/actions/runs/5389205358/jobs/9783031205#step:10:68,) which tell us the commit was released as version `0.24.0-33-a3c0851a-SNAPSHOT`, which is seen here:

https://oss.sonatype.org/content/repositories/snapshots/org/scala-steward/scala-steward-core_2.13/0.24.0-33-a3c0851a-SNAPSHOT/

We can tell the Scala Steward GitHub Action to use this version with the [`scala-steward-version`](https://github.com/scala-steward-org/scala-steward-action/blob/c5e82c25942c921a296818e15354a0bf65701146/action.yml#L135) config parameter.

See the comments from mzuehlke & alejandrohdezma here: https://github.com/scala-steward-org/scala-steward/pull/3102#issuecomment-1623397484
