### PR TITLE
Add labels

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -35,3 +35,4 @@ jobs:
           github-app-key: ${{ secrets.private_key }}
           repos-file: REPOSITORIES.md # possibly no longer necessary, thanks to `github-app-*` configuration
           repo-config: common-config/scala-steward.conf # from checkout of guardian/scala-steward-public-repos
+          other-args: "--add-labels"

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -24,3 +24,5 @@ dependencyOverrides = [
 # solutions to this going forward; this is a crude sticking-plaster to avoid us
 # sleepwalking into lots of fees.
 updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ]
+
+pullRequests.customLabels = [ "dependencies" ]

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,6 +1,6 @@
 pullRequests.grouping = [
-  { name = "aws", "title" = "AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
-  { name = "non_aws", "title" = "Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
+  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
+  { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
 # Only limit frequency on dependencies which automatically release updates as frequently


### PR DESCRIPTION
## What does this change?

* Adds `dependencies` label to Scala Steward PRs.
* update PR titles to be semantic and match Dependabot

The labels are helpful to identify bot updates and combine them into a single PR (across Dependabot and Scala Steward).

## How to test

Run.