### PR TITLE
Raise a single (grouped) PR at most weekly

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,15 +1,14 @@
+# At most we want pull requests for a dependency/group no more than once a week.
+# This is to balance responsiveness with dependency management fatigue.
+pullRequests.frequency = "7 days"
+
 pullRequests.grouping = [
-  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
-  { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
+  { name = "all", "title" = "chore(deps): Scala Steward updates", "filter" = [{"group" = "*"}] },
 ]
 
-# Only limit frequency on dependencies which automatically release updates as frequently
-# as daily, without those dependencies having meaningful security value.
+# Libraries in these common groupings are known to release daily, so we limit
+# their frequency to avoid spam.
 dependencyOverrides = [
-  {
-    dependency = { groupId = "com.amazonaws" },
-    pullRequests = { frequency = "7 days" }
-  },
   {
     dependency = { groupId = "software.amazon.awssdk" },
     pullRequests = { frequency = "30 days" }


### PR DESCRIPTION
## What does this change?

* consolidates AWS and non-AWS into a single group
* adds a global frequency of 7 days to avoid PRs raised more than once a week

This is to balance two competing aims:

* quick and regular adoption of updates
* keeping the number of PRs low, to prevent overly burdening teams

Some custom frequency settings are preserved for AWS and Google libraries to reduce noise here.

## How to test

run

## How can we measure success?

Fewer PRs. Note, Snyk will still alert on any critical security issues.

This change is likely to cut Scala Steward PRs to a most 1/week per configured repo. At the moment it can be 2+ for each.

## Have we considered potential risks?

The original rationale for AWS/non-AWS is likely to separate smaller and safer changes (AWS) from others that are likely more important but also more challenging.

In practice, I am not convinced this divide is worth the PR overhead. The vast majority of changes we observe across both groups are non-breaking so a single grouping seems sensible here.

(Caveat: interested in other thoughts here - e.g. @rtyley and @akash1810 when back as somewhat subjective here. I should note though that we in DevX are I think the heaviest users of SS in terms of n. of repos so most impacted by these kinds of changes.)