### PR TITLE
Ignore non-LTS versions of Scala 3 library

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -20,9 +20,17 @@ dependencyOverrides = [
    }
 ]
 
-# Ignore Akka updates following licence changes. Note, we hope to provide better
-# solutions to this going forward; this is a crude sticking-plaster to avoid us
-# sleepwalking into lots of fees.
-updates.ignore = [ { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"} ]
+updates.ignore = [
+
+  # Ignore Akka updates following licence changes. Note, we hope to provide better
+  # solutions to this going forward; this is a crude sticking-plaster to avoid us
+  # sleepwalking into lots of fees.
+  { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"},
+
+  # Ignore updates to non-LTS versions of the Scala 3 library.
+  # See https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#owners-of-commercial-projects
+  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
+  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
+]
 
 pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
This will avoid repos updating to non-LTS versions by default.
Individual repos can always overrule it if required.
