### PR TITLE
use java 21 for scala steward

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -26,6 +26,13 @@ jobs:
           repository: guardian/scala-steward-public-repos
           path: common-config
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "corretto"
+          cache: sbt
+
       - name: Execute Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.64.0
 


### PR DESCRIPTION
Recently we have upgraded support-service-lambdas to java 21.
PR: https://github.com/guardian/support-service-lambdas/pull/2195#issuecomment-1997148927

This has caused scala steward to fail due to the java 21 check.

We could relax the check - as it was probably only added becasue scala didn't used to support recent version of java, and you would get weird errors. 

Having said that, why not run scala steward on a recent LTS java, as it might be quicker?

This PR updates scala steward to use java 21 as per https://github.com/marketplace/actions/scala-steward-github-action#:~:text=triggering%20a%20run-,Specify%20JVM%20version,-Updating%20a%20specific