### PR TITLE
Try to fix setup-java action - remove sbt caching

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           java-version: "21"
           distribution: "corretto"
-          cache: sbt
 
       - name: Execute Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.64.0


### PR DESCRIPTION
See https://github.com/guardian/scala-steward-public-repos/pull/67#issuecomment-1997972775 - this does fix the setup-java config, which is good - but as @johnduffell predicted, we do have a project that can't handle Java 21 yet:

https://github.com/guardian/scala-steward-public-repos/actions/runs/8285120256/job/22672145296#step:6:2622

Looks like just one project though: [`guardian/mobile-save-for-later`](https://github.com/guardian/mobile-save-for-later)