### PR TITLE
Ignore Twitter Scrooge updates

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -32,7 +32,9 @@ updates.ignore = [
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
 
-  # Ignore updates to Scrooge Thrift.
+  # Ignore updates to Scrooge Thrift. This will be removed once the CAPI team renames
+  # in https://github.com/guardian/content-api-models any fields that are reserved keywords in Scrooge, e.g.
+  # https://github.com/guardian/content-api-models/blob/ac9b9cb6826717a053667a80c5b06e543f8d669a/models/src/main/thrift/content/v1.thrift#L391-L392
   # See https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903
   {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.2.0"}},
 ]

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -32,9 +32,8 @@ updates.ignore = [
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
 
-  # Ignore updates to Apache Thrift and Scrooge Thrift.
+  # Ignore updates to Scrooge Thrift.
   # See https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903
-  {groupId = "org.apache.thrift", artifactId = "libthrift", version = {prefix = "0.20."}},
   {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.12."}},
 ]
 

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -31,6 +31,11 @@ updates.ignore = [
   # See https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#owners-of-commercial-projects
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
   {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
+
+  # Ignore updates to Apache Thrift and Scrooge Thrift.
+  # See https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903
+  {groupId = "org.apache.thrift", artifactId = "libthrift", version = {prefix = "0.20."}},
+  {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.12."}},
 ]
 
 pullRequests.customLabels = [ "dependencies" ]

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -34,7 +34,7 @@ updates.ignore = [
 
   # Ignore updates to Scrooge Thrift.
   # See https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903
-  {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.12."}},
+  {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.2.0"}},
 ]
 
 pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
## What does this change?
Adds Twitter Scrooge to the `updates.ignore` list.

## Why?
Scrooge has updated their forbidden keywords to be the same as Apache Thrift: https://github.com/twitter/scrooge/commit/884f360361bc4abf2e2c91ada1e9cbc15f584b0d. CAPI uses the word `end` which is a reserved keyword, so any Scrooge upgrade above [`22.2.0`](https://github.com/twitter/scrooge/releases/tag/scrooge-22.2.0) will fail until we rename this field. See also: https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903. By ignoring these dependencies we're unblocking Scala Steward to raise PRs with other upgrades.

