### PR TITLE
Note that need write access to run the workflow manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ will need to be a repo admin to do this):
 
 1. Click `Configure` on [the GitHub app's page](https://github.com/apps/gu-scala-steward-public-repos): ![image](https://github.com/guardian/scala-steward-public-repos/assets/52038/7f120478-e5e1-4117-9e35-323cc170d982)
 2. On the next page, add your repo to the list of selected repos, and click `Save`.
-3. Manually run [the GitHub workflow](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml)
+3. If you have `Write` access to this repo, manually run [the GitHub workflow](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml), otherwise wait until the next scheduled run
    to check that Scala Steward is now processing your repo too - **you're all done!**


### PR DESCRIPTION
See https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually