### PR TITLE
Fix failing workflows by making sbt available

### DIFF
--- a/.github/workflows/reusable-scala-steward.yml
+++ b/.github/workflows/reusable-scala-steward.yml
@@ -32,6 +32,8 @@ jobs:
           java-version: "21"
           distribution: "corretto"
 
+      - uses: sbt/setup-sbt@v1.1.0
+
       - name: Execute Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.65.0
 


### PR DESCRIPTION
See also https://github.com/guardian/janus/pull/4385 
More at https://eed3si9n.com/setup-sbt/




## Testing

https://github.com/guardian/scala-steward-public-repos/actions/runs/11345941737

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/3bcba0ee-9fce-4663-9221-51453f8fa333">

We ran the workflow on this branch and it ran successfully




