### PR TITLE
Introduce PR group for Guardian libraries, slow cadence on other PRs

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,23 +1,23 @@
 pullRequests.grouping = [
+  { name = "gu", "title" = "chore(deps): Guardian library updates", "filter" = [{"group" = "com.gu"}] },
   { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
   { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
-# Only limit frequency on dependencies which automatically release updates as frequently
-# as daily, without those dependencies having meaningful security value.
+# For deps that are neither Guardian nor excessively chatty, this seems a reasonable default, given that we group
+# PRs - if the PRs are too infrequent, they may grow too large and hard to debug if they go wrong.
+pullRequests.frequency = "7 days"
+
 dependencyOverrides = [
   {
-    dependency = { groupId = "com.amazonaws" },
-    pullRequests = { frequency = "7 days" }
+    dependency = { groupId = "com.gu" }, # A Guardian library update is generally more important to us
+    pullRequests = { frequency = "2 days" }
   },
-  {
-    dependency = { groupId = "software.amazon.awssdk" },
-    pullRequests = { frequency = "30 days" }
-  },
-  {
-    dependency = { groupId = "com.google.apis" },
-    pullRequests = { frequency = "30 days" }
-   }
+  # Some libraries automatically release updates as frequently as daily, without those dependencies
+  # having meaningful security value. So we slow the rate of updates to 'monthly':
+  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "com.amazonaws" },
+  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "software.amazon.awssdk" },
+  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "com.google.apis" }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
These changes come out of discussions I've had with people on various teams (eg MAPI, DevX, Ophan) across the department - the teams all have different needs, so no perfect single set of defaults exists, but I've done my best to take feedback into account! Happy to discuss further in this PR.

## Changes

* Add new PR group for Guardian libraries (`com.gu`) - Guardian library updates are generally more important to us, so allow a frequency of **2 days** on these (our original grouping came with https://github.com/guardian/scala-steward-public-repos/pull/40)
* Slow down AWS SDK v1 dependency PRs from weekly to the same cadence as AWS SDK v2 - **once per month**. Note that projects _should_ be  https://github.com/guardian/maintaining-scala-projects/issues/9, as v1 is in maintenance mode and will soon be EOL.
* Slow down PRs for 'normal' third party dependencies (deps that are neither Guardian nor excessively chatty like AWS) to **weekly** (previously, no frequency limit existed at all in our default config). This is the hardest parameter to tune- some teams, like DevX Security, prefer a monthly cadence, but for other teams, that have fewer but larger repos (closer to a monorepo for the team, like Ophan), a month of delay will lead to a single really large PR with many updates that's harder to debug if a cause of failure needs pin-pointing - releasing a smaller number of updates at a weekly cadence reduces the risk with each release.

### Repo-specific configuration, for teams that would like to tweak the defaults

If teams want to adjust the cadence from weekly for 'normal' third party dependency PRs, they can use [per-repo](https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md) `.scala-steward.conf` just specifying `pullRequests.frequency` like this:

```
pullRequests.frequency = "30 days"
```

As it happens, now that AWS SDK v1 dependency PRs have now been slowed down, for a DevX repo like `security-hq`, no further customisation would be required to achieve something like a monthly cadence, as [all the PRs Scala Steward has been raising for `security-hq`](https://github.com/guardian/security-hq/pulls?q=is%3Apr+author%3Aapp%2Fgu-scala-steward-public-repos) are just for AWS dependencies.

Note also that in Scala Steward, if you add repo-specific config, the repo-specific fields wipe out the 'default' config fields, but `dependencyOverrides.pullRequests.frequency` fields override `pullRequests.frequency`, no matter where they comes from (the original global config, or the repo-specific config) - so if you want a custom cadence on AWS artifacts, you'll need to specifically override the `dependencyOverrides.pullRequests.frequency` settings, rather than just using `pullRequests.frequency`.