### PR TITLE
Add CODEOWNERS file for Scala Guild

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/scala-guild


### PR DESCRIPTION
Adding the [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file ensures that the Scala Guild will automatically be requested for review when someone opens a pull request on this repo.

Note that the team-by-team Grafana reports produced by DevX _don't_ use the information in the CODEOWNERS.  The determination of which team is responsible for a repo or security compliance issue tends to come down to these two factors:

* For a repo: which GitHub teams have Admin access to the repo
* For an AWS security issue: who owns the AWS account

For instance, [this report](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/dependency-vulnerabilities-by-team?orgId=1&var-repo_owner=scala-guild) on dependency vulnerabilities on repos, which is filtered for the Scala Guild, is showing repos for which the @guardian/scala-guild GitHub Team **have admin access**.

It's a shame that we need to define ownership of Scala Guild repos in two different ways (GitHub Team admin access & CODEOWNERS file) but I guess we can live with it!
