### PR TITLE
Reduce label-noise on generated PRs

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -39,4 +39,5 @@ updates.ignore = [
   {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.2.0"}},
 ]
 
+pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels
 pullRequests.customLabels = [ "dependencies" ]


### PR DESCRIPTION
@akash1810 on DevX [asked](https://chat.google.com/room/AAAAxU6hmMI/Z5b1diy4PoU/Z5b1diy4PoU?cls=10) if it was possible to tune the labels applied to pull-requests raised by Scala Steward. There are a lot of labels added by Scala Steward - for instance, on this PR Akash pointed to - https://github.com/guardian/riff-raff/pull/1409 :

```
artifact-migrations
commit-count:n:22
dependencies
early-semver-major
early-semver-minor
early-semver-patch
early-semver-pre-release
library-update
old-version-remains
sbt-plugin-update
semver-spec-major
semver-spec-minor
semver-spec-patch
semver-spec-pre-release
test-library-update
version-scheme:early-semver
version-scheme:semver-spec
```

Of all these labels, Akash only found the `dependencies` one useful - I'm not aware of the others being used for anything?

The labels were first introduced with https://github.com/guardian/scala-steward-public-repos/pull/58 in August 2023, but I _think_ these were for DevX tooling that did grouping of PRs. As Scala Steward is now reliably grouping its own PRs, I don't think we're getting any value from the labels there.
