### PR TITLE
Avoid broken content-api-firehose-client release

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -37,6 +37,9 @@ updates.ignore = [
   # https://github.com/guardian/content-api-models/blob/ac9b9cb6826717a053667a80c5b06e543f8d669a/models/src/main/thrift/content/v1.thrift#L391-L392
   # See https://trello.com/c/1rp2MVVA and https://github.com/guardian/content-api/issues/2903
   {groupId = "com.twitter", artifactId = "scrooge-core", version = {prefix = "22.2.0"}},
+
+  # Ignore this broken release: https://github.com/guardian/content-api-firehose-client/releases/tag/v1.0.26
+  {groupId = "com.gu", artifactId = "content-api-firehose-client", version = "1.0.26"},
 ]
 
 pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels


### PR DESCRIPTION
See https://github.com/guardian/content-api-firehose-client/releases/tag/v1.0.26

