### PR TITLE
chore: Remove redundant LTS-handling config

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -27,11 +27,6 @@ updates.ignore = [
   # sleepwalking into lots of fees.
   { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"},
 
-  # Ignore updates to non-LTS versions of the Scala 3 library.
-  # See https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#owners-of-commercial-projects
-  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
-  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
-
   # Ignore updates to Scrooge Thrift. This will be removed once the CAPI team renames
   # in https://github.com/guardian/content-api-models any fields that are reserved keywords in Scrooge, e.g.
   # https://github.com/guardian/content-api-models/blob/ac9b9cb6826717a053667a80c5b06e543f8d669a/models/src/main/thrift/content/v1.thrift#L391-L392


### PR DESCRIPTION
We added some config in #63 to ensure that projects didn't inadvertently step out of LTS versions of Scala and into [Scala Next](https://www.scala-lang.org/development/).

However, since scala-steward-org/scala-steward#3328 this is now redundant as Scala Steward has an internal mechanism for staying on either an LTS or a `Next` track.  Any project on an LTS version of Scala will only be bumped to successive LTS versions.  If a project wants to use `Next` versions it just has to be bumped manually to a `Next` version and that will then automatically be kept up to date.
