### PR TITLE
Revert "chore: Remove redundant LTS-handling config"

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -27,6 +27,11 @@ updates.ignore = [
   # sleepwalking into lots of fees.
   { groupId = "com.typesafe.akka" }, {groupId = "com.lightbend.akka"},
 
+  # Ignore updates to non-LTS versions of the Scala 3 library.
+  # See https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html#owners-of-commercial-projects
+  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.4."}},
+  {groupId = "org.scala-lang", artifactId = "scala3-library", version = {prefix = "3.5."}},
+
   # Ignore updates to Scrooge Thrift. This will be removed once the CAPI team renames
   # in https://github.com/guardian/content-api-models any fields that are reserved keywords in Scrooge, e.g.
   # https://github.com/guardian/content-api-models/blob/ac9b9cb6826717a053667a80c5b06e543f8d669a/models/src/main/thrift/content/v1.thrift#L391-L392


### PR DESCRIPTION
The [public repos scala steward job](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml) has been failing since PR 91 was merged. I can't see why that would have broken it (and the [private scala steward job](https://github.com/guardian/scala-steward-private-repos/actions/workflows/private-repos-scala-steward.yml) is still working), but just in case I'm going to run it from this PR and see if that fixes it.

Reverts guardian/scala-steward-public-repos#91