### PR TITLE
Fix `pullRequests.grouping` config to include sub-group ids

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,6 +1,6 @@
 pullRequests.grouping = [
-  { name = "gu", "title" = "chore(deps): Guardian library updates", "filter" = [{"group" = "com.gu"}] },
-  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
+  { name = "gu", "title" = "chore(deps): Guardian library updates", "filter" = [{"group" = "com.gu"}], {"group" = "com.gu.*"}] },
+  { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon"}, {"group" = "software.amazon.*"}, {"group" = "com.amazonaws"}, {"group" = "com.amazonaws.*"}] },
   { name = "non_aws", "title" = "chore(deps): Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
 ]
 


### PR DESCRIPTION
@vlbee pointed out to me that artifacts like `"software.amazon.kinesis" % "amazon-kinesis-client"` were being included in _"**Non**-AWS dependency updates"_ (like https://github.com/guardian/mobile-notifications-content/pull/150) - and that's incorrect, we would expect that to go into the AWS updates.

It turns out that our _"AWS dependency updates"_ and _"Guardian library updates"_ grouping rules were both failing to match all the group ids we would want (unfortunately, specifying, eg, `com.gu`, does not also match `com.gu.play-googleauth`) - this change updates our global `.scala-steward.conf` to fix this.

## See also

* https://github.com/scala-steward-org/scala-steward/issues/3655
* https://github.com/scala-steward-org/scala-steward/pull/3654

