### PR TITLE
Enable dependency-cooldowns

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -20,6 +20,10 @@ dependencyOverrides = [
   { pullRequests = { frequency = "30 days" }, dependency = { groupId = "com.google.apis" } }
 ]
 
+updates.cooldown = {
+  minimumAge: "7 days"
+}
+
 updates.ignore = [
 
   # Ignore Akka updates following licence changes. Note, we hope to provide better


### PR DESCRIPTION
Recent Scala Steward release [v0.38.0](https://github.com/scala-steward-org/scala-steward/releases/tag/v0.38.0) included [dependency-cooldown](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) support, added by @emdash-ie & @rtyley!

* https://github.com/scala-steward-org/scala-steward/pull/3762

This change configures our Scala Steward to have a **dependency-cooldown period of 7 days** - Scala Steward will only raise PRs to upgrade to artifact versions it's known about for at least 7 days. This gives our supply-chain-security vendors 7 days to identify malicious artifacts before we start using them.

## Merge once Scala Steward has gathered 7 days of artifact-age data

From the release notes of Scala Steward [v0.38.0](https://github.com/scala-steward-org/scala-steward/releases/tag/v0.38.0):

> ...in this new release, we've had to update the format of the file-db stored by Scala Steward to additionally store the 'first-seen' time for every artifact Scala Steward encounters - that's the only way for Scala Steward to work out if the Maven artifact is too recent for the cooldown period. When your Scala Steward instance is first updated to this release (v0.38.0) it'll start saving that info, but no artifacts will be recorded as being _older_ than that upgrade point. So if you want to configure a cooldown period of, for example, 7 days, you may want to wait until 7 days _after_ the update to Scala Steward v0.38.0 has occurred - otherwise the config will be somewhat more impactful than intended, with _all_ updates being rejected until those 7 days have passed.

We started running with Scala Steward v0.38.0 on Friday 6th March, so should be good to merge this on or after Friday 13th March.

## Is 7 days enough?

Three examples of Maven Central attacks & windows of vulnerability are now noted in the original GitHub issue:

* https://github.com/scala-steward-org/scala-steward/issues/3757

The windows of vulnerability are 6 days, 10 days, and over 1 year. Reasonably, dependency cooldown might be extended to cover the first 2 (but not to over 1 year!), suggesting a cooldown period of 2 weeks. However, as noted above, Scala Steward has to accumulate age-of-artifact data before it can sensibly apply the filter, and I'd rather not have to wait over 2 weeks to try out this new feature! We can extend the cooldown period later.


## Examples of Dependency Cooldowns (but with Dependabot) at the Guardian

* https://github.com/guardian/android-news-app/pull/12375
* https://github.com/guardian/service-catalogue/pull/1769