### PR TITLE
Update Jackson grouping

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,7 +1,8 @@
 pullRequests.grouping = [
   { name = "gu", "title" = "chore(deps): Guardian library updates", "filter" = [{"group" = "com.gu"}, {"group" = "com.gu.*"}] },
   { name = "aws", "title" = "chore(deps): AWS dependency updates", "filter" = [{"group" = "software.amazon"}, {"group" = "software.amazon.*"}, {"group" = "com.amazonaws"}, {"group" = "com.amazonaws.*"}] },
-  { name = "jackson", "title" = "chore(deps): Jackson dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.*"}] },
+  # In v3, the Jackson group changed from "com.fasterxml.jackson.*" to "tools.jackson.*"
+  { name = "jackson", "title" = "chore(deps): Jackson dependency updates", "filter" = [{"group" = "com.fasterxml.jackson.*"}, {"group" = "tools.jackson.*"}] },
   { name = "patches", "title" = "chore(deps): Patch updates", filter = [{ "version" = "patch" }] }
 ]
 


### PR DESCRIPTION
Some libraries are now using Jackson v3 in their dependency tree.
But v3 has a different maven group so they aren't being picked up in the Jackson grouping.
This PR changes that by including them in the same group as the v2 Jackson dependencies.
