### PR TITLE
Add remove a public repo section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ will need to be a repo admin to do this):
 2. On the next page, add your repo to the list of selected repos, and click `Save`.
 3. If you have `Write` access to this repo, manually run [the GitHub workflow](https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml), otherwise wait until the next scheduled run
    to check that Scala Steward is now processing your repo too - **you're all done!**
+
+## How to remove a *public* repo, that no longer uses Scala from scanning by Scala Steward
+
+Only repo admins can do this, if you are not a repo admin, the repo will not appear in the list of repos that you can deselect even if it is part of the list. In that case, you will need to ask a repo admin to do it for you.
+
+The process is the same as [adding a repo](#how-to-add-a-new-public-repo-for-scanning-by-scala-steward), but instead of selecting the repo, you will need to deselect it and click `Save` to remove it from the list of repos that Scala Steward scans.


### PR DESCRIPTION
## What does this change?

Add remove a public repo section to README to clarify that only repo admins are able to see repo in list.