### PR TITLE
Add new workflow to patch vulnerabilities

### DIFF
--- a/.github/workflows/fix-security-vulnerability.yml
+++ b/.github/workflows/fix-security-vulnerability.yml
@@ -21,59 +21,15 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: read
-
 jobs:
-  scala-steward:
-    name: fix-security-vulnerability
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate Scala Steward configuration
-        env:
-          GROUP_ID: ${{ inputs.group_id }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          cat > security-fix-scala-steward.conf <<EOF
-          updates.allow = [{ groupId = "$GROUP_ID" }]
-          updates.pin = [{ groupId = "$GROUP_ID", version = { exact = "$VERSION" } }]
-          pullRequests.frequency = "@asap"
-          pullRequests.draft = ${{ inputs.draft }}
-          commits.message = "chore(deps): Update \${artifactName} from \${currentVersion} to \${nextVersion}"
-          pullRequests.grouping = [{
-            name = "security-fix",
-            title = "chore(deps): Update $GROUP_ID to $VERSION",
-            filter = [{"group" = "*"}]
-          }]
-          pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels
-          pullRequests.customLabels = [ "dependencies" ]
-          EOF
-
-      - name: Generate repos file
-        env:
-          TARGET_REPOS: ${{ inputs.target_repos }}
-        run: |
-          for repo in $(echo "$TARGET_REPOS" | tr ',' ' '); do
-            echo "- guardian/$repo" >> security-fix-repos.md
-          done
-
-      - name: Upload generated files
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: generated-config
-          path: |
-            security-fix-scala-steward.conf
-            security-fix-repos.md
-
-      - name: Execute Scala Steward
-        uses: scala-steward-org/scala-steward-action@b186ab858ce163f9af7b016fac32cfb3f2c2f503 # v2.88.0
-        with:
-          github-app-id: 214238
-          github-app-installation-id: 26822732
-          github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
-          github-app-auth-only: true
-          repos-file: security-fix-repos.md
-          repo-config: security-fix-scala-steward.conf
-          other-args: "--add-labels"
+  call-reusable-workflow:
+    uses: ./.github/workflows/reusable-fix-security-vulnerability.yml
+    with:
+      app_id: "214238"
+      app_installation_id: "26822732"
+      group_id: ${{ inputs.group_id }}
+      version: ${{ inputs.version }}
+      target_repos: ${{ inputs.target_repos }}
+      draft: ${{ inputs.draft }}
+    secrets:
+      private_key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}

--- a/.github/workflows/fix-security-vulnerability.yml
+++ b/.github/workflows/fix-security-vulnerability.yml
@@ -1,0 +1,76 @@
+name: Fix security vulnerability
+
+on:
+  workflow_dispatch:
+    inputs:
+      group_id:
+        description: 'GroupId of the libraries to target. Updates all artifacts of that group. (e.g. The groupId for `software.amazon.awssdk:cloudwatch` is `software.amazon.awssdk`)'
+        required: true
+        type: string
+      version:
+        description: 'The version to update to (e.g. 2.44.7)'
+        required: true
+        type: string
+      target_repos:
+        description: 'Comma-separated list of repo names to target (e.g. amiable, frontend).'
+        required: true
+        type: string
+      draft:
+        description: 'Whether to create pull requests as drafts'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  scala-steward:
+    name: fix-security-vulnerability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate Scala Steward configuration
+        env:
+          GROUP_ID: ${{ inputs.group_id }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          cat > security-fix-scala-steward.conf <<EOF
+          updates.allow = [{ groupId = "$GROUP_ID" }]
+          updates.pin = [{ groupId = "$GROUP_ID", version = { exact = "$VERSION" } }]
+          pullRequests.frequency = "@asap"
+          pullRequests.draft = ${{ inputs.draft }}
+          commits.message = "chore(deps): Update \${artifactName} from \${currentVersion} to \${nextVersion}"
+          pullRequests.grouping = [{
+            name = "security-fix",
+            title = "chore(deps): Update $GROUP_ID to $VERSION",
+            filter = [{"group" = "*"}]
+          }]
+          pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels
+          pullRequests.customLabels = [ "dependencies" ]
+          EOF
+
+      - name: Generate repos file
+        env:
+          TARGET_REPOS: ${{ inputs.target_repos }}
+        run: |
+          for repo in $(echo "$TARGET_REPOS" | tr ',' ' '); do
+            echo "- guardian/$repo" >> security-fix-repos.md
+          done
+
+      - name: Upload generated files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-config
+          path: |
+            security-fix-scala-steward.conf
+            security-fix-repos.md
+
+      - name: Execute Scala Steward
+        uses: scala-steward-org/scala-steward-action@b186ab858ce163f9af7b016fac32cfb3f2c2f503 # v2.88.0
+        with:
+          github-app-id: 214238
+          github-app-installation-id: 26822732
+          github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
+          github-app-auth-only: true
+          repos-file: security-fix-repos.md
+          repo-config: security-fix-scala-steward.conf
+          other-args: "--add-labels"

--- a/.github/workflows/fix-security-vulnerability.yml
+++ b/.github/workflows/fix-security-vulnerability.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   call-reusable-workflow:
     uses: ./.github/workflows/reusable-fix-security-vulnerability.yml

--- a/.github/workflows/fix-security-vulnerability.yml
+++ b/.github/workflows/fix-security-vulnerability.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   scala-steward:
     name: fix-security-vulnerability

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -1,0 +1,88 @@
+name: Reusable fix security vulnerability workflow
+
+on:
+  workflow_call:
+    inputs:
+      app_id:
+        required: true
+        type: string
+      app_installation_id:
+        required: true
+        type: string
+      group_id:
+        description: 'GroupId of the libraries to target. Updates all artifacts of that group. (e.g. The groupId for `software.amazon.awssdk:cloudwatch` is `software.amazon.awssdk`)'
+        required: true
+        type: string
+      version:
+        description: 'The version to update to (e.g. 2.44.7)'
+        required: true
+        type: string
+      target_repos:
+        description: 'Comma-separated list of repo names to target (e.g. amiable, frontend).'
+        required: true
+        type: string
+      draft:
+        description: 'Whether to create pull requests as drafts'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      private_key:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  scala-steward:
+    name: fix-security-vulnerability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate Scala Steward configuration
+        env:
+          GROUP_ID: ${{ inputs.group_id }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          cat > security-fix-scala-steward.conf <<EOF
+          updates.allow = [{ groupId = "$GROUP_ID" }]
+          updates.pin = [{ groupId = "$GROUP_ID", version = { exact = "$VERSION" } }]
+          pullRequests.frequency = "@asap"
+          pullRequests.draft = ${{ inputs.draft }}
+          commits.message = "chore(deps): Update \${artifactName} from \${currentVersion} to \${nextVersion}"
+          pullRequests.grouping = [{
+            name = "security-fix",
+            title = "chore(deps): Update $GROUP_ID to $VERSION",
+            filter = [{"group" = "*"}]
+          }]
+          pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels
+          pullRequests.customLabels = [ "dependencies" ]
+          EOF
+
+      - name: Generate repos file
+        env:
+          TARGET_REPOS: ${{ inputs.target_repos }}
+        run: |
+          for repo in $(echo "$TARGET_REPOS" | tr ',' ' '); do
+            echo "- guardian/$repo" >> security-fix-repos.md
+          done
+
+      - name: Upload generated files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-config
+          path: |
+            security-fix-scala-steward.conf
+            security-fix-repos.md
+
+      - name: Execute Scala Steward
+        uses: scala-steward-org/scala-steward-action@b186ab858ce163f9af7b016fac32cfb3f2c2f503 # v2.88.0
+        with:
+          github-app-id: ${{ inputs.app_id }}
+          github-app-installation-id: ${{ inputs.app_installation_id }}
+          github-app-key: ${{ secrets.private_key }}
+          github-app-auth-only: true
+          repos-file: security-fix-repos.md
+          repo-config: security-fix-scala-steward.conf
+          other-args: "--add-labels"

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -1,4 +1,4 @@
-name: Reusable fix security vulnerability workflow
+name: Reusable workflow to fix a security vulnerability
 
 on:
   workflow_call:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a new on-demand workflow to facilitate patching vulnerabilities across a set of repos. 

It is similar to the existing [targeted PRs workflow](https://github.com/guardian/scala-steward-public-repos/blob/main/.github/workflows/generate-targeted-prs.yml), but with a different focus. The idea is to pass a `groupId`, `version` and a list of repos (for example `software.amazon.awssdk`, `2.44.7`, `riff-raff, amigo`), and the workflow will use scala steward to open PRs to update `software.amazon.awssdk` to `2.44.7` in those repos.

In a way, this is a manual approximation of how "dependabot security updates" works. Regardless of what schedule dependabot is configured to run in a repo, when there is a security patch available "dependabot security updates" will open a PR immediately.

Likewise, this workflow runs scala steward on a repo with an isolated configuration template that only updates the specified dependency immediately.

This matches the way devx relops manage addressing vulnerabilities. As soon as one is flagged, we created a card, and the person assigned to it will typically do the work manually, going repo by repo and opening a PR with the fix. Sometimes, a repo will already have a PR opened because the scala steward scheduled lined up by coincidence.

I briefly spoke with devx security about implementing this workflow, and they were also interested in trying it out. It's possible that other teams in the department might also find this useful.

### Some design considerations

My test case (explained below) was to upgrade the awssdk, so I only needed to specify `groupId`. It's likely that being able to specify `artifactId` is also useful, but I haven't implemented it in this iteration.

I considered passing a github team instead of a list of repos, but that requires permissions to do a lookup of what repos a particular team owns, which we do not have available in this context.

If the vulnerability is a transitive dependency, which happens often, it can be a bit of a pain to determine which package needs to be updated. I have a [proof of concept in grafana](https://metrics.gutools.co.uk/d/cfmnalocntt6of/ja-vulnerabilities?orgId=1&from=now-6h&to=now&timezone=browser) of how to obtain this information from service catalogue that I'm hoping to make available more widely.

It would also be useful to have this available for private repos. I haven't figured out a good strategy to share the code and avoid duplication, so I'm open to suggestions!

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Triggering a workflow using the ui (the `workflow_dispatch` trigger) is only available for workflows on `main`. To test this I ran the workflow on `push` with default values for the input options.

My test case was addressing [netty vulnerabilities](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/dependency-vulnerabilities-by-team?orgId=1&var-REPO_OWNER=$__all&from=now-6h&to=now&timezone=browser&var-SCOPE=runtime&refresh=5s) by bumping the awssdk to the latest version in all devx affected repos at once:

* [amiable](https://github.com/guardian/amiable/pull/935)
* [riff-raff](https://github.com/guardian/riff-raff/pull/1608)
* [prism](https://github.com/guardian/prism/pull/1141)
* [anghammarad](https://github.com/guardian/anghammarad/pull/405)
* [elastic-search-monitor](https://github.com/guardian/elastic-search-monitor/pull/345)

[Github action log](https://github.com/guardian/scala-steward-public-repos/actions/runs/26161459978/job/76954127994)

