### PR TITLE
Reduce PR frequency to compensate for us no longer grouping so many PRs

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -6,20 +6,13 @@ pullRequests.grouping = [
   { name = "patches", "title" = "chore(deps): Patch updates", filter = [{ "version" = "patch" }] }
 ]
 
-# For deps that are neither Guardian nor excessively chatty, this seems a reasonable default, given that we group
-# PRs - if the PRs are too infrequent, they may grow too large and hard to debug if they go wrong.
-pullRequests.frequency = "7 days"
+pullRequests.frequency = "30 days"
 
 dependencyOverrides = [
   {
     dependency = { groupId = "com.gu" }, # A Guardian library update is generally more important to us
     pullRequests = { frequency = "2 days" }
-  },
-  # Some libraries automatically release updates as frequently as daily, without those dependencies
-  # having meaningful security value. So we slow the rate of updates to 'monthly':
-  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "com.amazonaws" } },
-  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "software.amazon.awssdk" } },
-  { pullRequests = { frequency = "30 days" }, dependency = { groupId = "com.google.apis" } }
+  }
 ]
 
 updates.cooldown = {


### PR DESCRIPTION
While in discussion with @jorgeazevedo , I realised that this comment in our Scala Steward config is misleading - specifically the _'given that we group PRs'_ part, introduced with PR #77 in October 2024:

https://github.com/guardian/scala-steward-public-repos/blob/017bc539179a16cf9b8cd7d5e9095fe19df189a2/scala-steward.conf#L9-L11

...recently we _stopped_ doing so much grouping, with PR #103 in November 2025. Reducing grouping _increases_ the number of PRs per unit time (Jorge mentions that within DevX the number of PRs is currently considered very high), and so I think it is reasonable to compensate by increasing the `pullRequests.frequency` period upwards from 7 days - and this is what we're now doing.
