### PR TITLE
Usability tweaks to security update

### DIFF
--- a/.github/workflows/fix-security-vulnerability.yml
+++ b/.github/workflows/fix-security-vulnerability.yml
@@ -1,4 +1,5 @@
 name: Fix security vulnerability
+run-name: "Update ${{ inputs.group_id }} to ${{ inputs.version }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -53,7 +53,7 @@ jobs:
           commits.message = "chore(deps): Update \${artifactName} from \${currentVersion} to \${nextVersion}"
           pullRequests.grouping = [{
             name = "security-fix",
-            title = "chore(deps): Update $GROUP_ID to $VERSION",
+            title = "chore(deps): Fix CVE by updating $GROUP_ID to $VERSION",
             filter = [{"group" = "*"}]
           }]
           pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -53,7 +53,7 @@ jobs:
           commits.message = "chore(deps): Update \${artifactName} from \${currentVersion} to \${nextVersion}"
           pullRequests.grouping = [{
             name = "security-fix",
-            title = "chore(deps): Fix CVE by updating $GROUP_ID to $VERSION",
+            title = "chore(deps): Update $GROUP_ID to $VERSION",
             filter = [{"group" = "*"}]
           }]
           pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -1,4 +1,5 @@
 name: Reusable workflow to fix a security vulnerability
+run-name: "Update ${{ inputs.group_id }} to ${{ inputs.version }}"
 
 on:
   workflow_call:
@@ -86,3 +87,13 @@ jobs:
           repos-file: security-fix-repos.md
           repo-config: security-fix-scala-steward.conf
           other-args: "--add-labels"
+
+      - name: Summarise run parameters
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+
+          ## Input variables
+          * group ID: \`${{ inputs.group_id }}\`
+          * version: \`${{ inputs.version }}\`
+          * repos: \`${{ inputs.target_repos }}\`
+          EOF

--- a/.github/workflows/reusable-fix-security-vulnerability.yml
+++ b/.github/workflows/reusable-fix-security-vulnerability.yml
@@ -1,5 +1,4 @@
 name: Reusable workflow to fix a security vulnerability
-run-name: "Update ${{ inputs.group_id }} to ${{ inputs.version }}"
 
 on:
   workflow_call:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a few usability improvements to the security update workflow

- Sets the run name, so we can at a glance understand what ran by looking at the execution list

<img width="1073" height="206" alt="Screenshot 2026-07-01 at 15 21 19" src="https://github.com/user-attachments/assets/e17d757c-c7f5-4e54-b213-a1927e16b41a" />

- List input variables in the job summary
<img width="707" height="389" alt="Screenshot 2026-07-01 at 15 23 23" src="https://github.com/user-attachments/assets/f5da2863-8a73-4567-a911-b090e9f23801" />

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

- Change PR subject to make them stand out more
<img width="855" height="178" alt="Screenshot 2026-07-01 at 15 24 02" src="https://github.com/user-attachments/assets/11441311-51da-4703-b71b-828c5944d843" />

## How has this change been tested?

I ran this from the private repo and capture the (lightly edited) screenshots!
