### PR TITLE
Avoid sbt 2 for now

### DIFF
--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -41,6 +41,11 @@ updates.ignore = [
 
   # Ignore this broken release: https://github.com/guardian/content-api-firehose-client/releases/tag/v1.0.26
   {groupId = "com.gu", artifactId = "content-api-firehose-client", version = "1.0.26"},
+
+  # Most of our repos can't use sbt 2 yet...
+  # Play apps will need Play 3.1 : https://github.com/playframework/playframework/issues/13319#issuecomment-4231534251
+  # Library repos will need sbt-version-policy to be released with this update: https://github.com/scalacenter/sbt-version-policy/pull/277
+  {groupId = "org.scala-sbt", artifactId = "sbt", version = {prefix = "2."}},
 ]
 
 pullRequests.includeMatchedLabels = "(?!)" // Reject all auto-generated labels


### PR DESCRIPTION
Many of our repos can't use sbt 2 yet...

* Play apps will need Play 3.1 : https://github.com/playframework/playframework/issues/13319#issuecomment-4231534251
* Library repos will need sbt-version-policy to be released with this update: https://github.com/scalacenter/sbt-version-policy/pull/277 -  but this is now released! So long as the project updates to sbt-version-policy [v3.3.0](https://github.com/scalacenter/sbt-version-policy/releases/tag/v3.3.0), it should be releasable.

...we can experiment with sbt 2 once some of those hurdles are overcome!

* https://www.scala-lang.org/blog/2026/06/29/sbt2.html
* https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html